### PR TITLE
Training WG page rewrite to make it more attractive.

### DIFF
--- a/workinggroups/_posts/2015-11-04-training.md
+++ b/workinggroups/_posts/2015-11-04-training.md
@@ -7,25 +7,23 @@ The HSF Training & Tutoring initiative is aimed at helping the research communit
 
 ## WikiToLearn - collaborative textbooks
 
-To this extent we have adopted an already existing and successful platform, named [WikiToLearn](http://en.wikitolearn.org/Main_Page), originally developed in Italy for University students to deploy our tutoring in software but now growing in numbers also outside Italy. The basic principle of this initiative is that researchers can seldom afford to spend time writing down training material or professors transcribing their courses for the benefit of students in general. On the other hand students already take note during lessons or during their own academic research: it is therefore much easier for them to publish these notes and reports in a publicly visible site. WikiToLearn is a wikimedia-based content management system, pretty much like Wikipedia, were anybody can add new material or complete already existing one. To strengthen the quality of published material, scientists and researches can furthermore sign a particular version to enhance it's quality level. The platform is currently officially backed by Wikimedia end the KDE organization, and has received support from the University of Milano-Bicocca and the University of Pisa.
-Under the category 'Physics/Software' WikiToLearn now has a [branch](http://it.wikitolearn.org/Main_HSF_Page) dedicated to the HSF effort. We plan, in the coming months, to recruit as many volunteers as possible to publish there training material in various software domains and help the community to grow accordingly.
+To achieve this goal, we adopted an already existing and successful platform. [WikiToLearn](http://en.wikitolearn.org/Main_Page). Originally developed in Italy, it was intended to allow University students to deploy our tutoring in software. It has now a growing usage also outside Italy. 
 
-## Potential other projects
+The basic principle of this initiative is that researchers can seldom afford to spend time writing down training material. The same applies for professors when it comes to transcribing their courses for the benefit of students in general. On the other hand, students often take notes during lessons or during their own academic research. The goal of the platform is to make easy for them to publish these notes and reports in a publicly visible site.
 
-We laid out a few training and education plans and possibilities:
+WikiToLearn is a wikimedia-based content management system, pretty much like Wikipedia, were anybody can add new material or complete already existing one. To strengthen the quality of published material, scientists and researches can furthermore sign a particular version to enhance it's quality level. The platform is currently officially backed by Wikimedia and the KDE organization, and has received support from the University of Milano-Bicocca and the University of Pisa.
 
- [HSF training and education notebook](https://docs.google.com/document/d/1E85vhzgFs37VOlTC6XTqvQOOmLEgAvamyvl4Iz-Sqm4/edit#heading=h.pstok39wu9vm)
+Under the category 'Physics/Software', WikiToLearn now has a [branch](http://it.wikitolearn.org/Main_HSF_Page) dedicated to the HSF effort. We plan, in the coming months, to recruit as many volunteers as possible to publish there training material in various software domains relevant to HSF.
 
-## Other acitivites in the field
+## Other training activities in HSF
 
-We set up a training section in the knowledge base 
+Many ideas are being discussed and are tracked down in the HSF training and education [notebook](https://docs.google.com/document/d/1E85vhzgFs37VOlTC6XTqvQOOmLEgAvamyvl4Iz-Sqm4/edit#heading=h.pstok39wu9vm).
 
-[Training section of the knowledge base](http://hepsoftware.org/e/training).
+Other actions in progress include:
 
-Here we started to collect training related organizations, events, software packages and alike. Please contribute to the knowledge base to fill out the content!
+* A [Training section](http://hepsoftware.org/e/training) in the HSF knowledge base] intended to collect training related events, organizations, software packages... **Please contribute to the knowledge base to help enriching the content**
 
-## Communication
+## How to participate ?
 
-We set up a discussion forum. Everbody is welcome to join and particpate:
-
-[HSF training and education working group forum](https://groups.google.com/forum/#!forum/hep-sf-training-wg)
+Everybody is welcome to join the [forum](https://groups.google.com/forum/#!forum/hep-sf-training-wg) dedicated to HSF training activities. This is the place where ideas and proposals are discussed and actions decided!
+  


### PR DESCRIPTION
This is an attempt to rewrite the training page in a more attractive wording... This is an attempt to address https://github.com/HEP-SF/hep-sf.github.io/pull/2#discussion_r44420032in https://github.com/HEP-SF/hep-sf.github.io/pull/2.