### PR TITLE
Fix to building proposal summary pages

### DIFF
--- a/gsoc/2017/summary.md
+++ b/gsoc/2017/summary.md
@@ -8,5 +8,10 @@ year: 2017
 
 {:.table .table-hover .table-striped}
 {% assign sorted_proposals = site.gsocproposals | sort: 'title' %}
-{% for proposal in sorted_proposals %}{% capture u_proposal_org %}{{ organization | upcase }}{% endcapture %}{% if proposal.year == page.year %}[ {{ proposal.title }} ]( {{ proposal.url }} ) |{% endif %}
+{% for proposal in sorted_proposals %}{% capture u_proposal_org %}{{ organization | upcase }}{% endcapture %}
+{%- assign strings = proposal.url | split: '/' -%}
+{%- assign proposal_year = strings[2] | plus: 0 -%}
+{%- if proposal_year == page.year %}
+| [ {{ proposal.title }} ]( {{ proposal.url }} ) |
+{%- endif -%}
 {% endfor %}


### PR DESCRIPTION
No longer needs page.year attribute
Avoid issues with liquid whitespace breaking the table into multiple pieces